### PR TITLE
Manage duplicate patients

### DIFF
--- a/hydrant/adapters/sites/skagit.py
+++ b/hydrant/adapters/sites/skagit.py
@@ -1,3 +1,4 @@
+import json
 from ...models.datetime import parse_datetime
 
 
@@ -46,3 +47,10 @@ class SkagitAdapter(object):
             if value:
                 yield attr, value
 
+    def unique_key(self):
+        """Returns a key value to represent this item as unique
+
+        Defined by adapters wishing to sort out duplicates, used in
+        comparison operators.
+        """
+        return json.dumps([self.name, self.birthDate])

--- a/hydrant/models/datetime.py
+++ b/hydrant/models/datetime.py
@@ -2,12 +2,18 @@ from datetime import datetime
 from flask import current_app
 from dateutil import parser
 
+WRAP_YEAR = 2025
+
 
 def parse_datetime(data, error_subject=None, none_safe=False):
     """Parse input string to generate a UTC datetime instance
 
     NB - date must be more recent than year 1900 or a ValueError
     will be raised.  (library limitation)
+
+    WRAP_YEAR (defined above) is used to determine how a 2 digit
+    year should be treated.  Values below WRAP year are assumed
+    to belong in year 20?? where as values above in 19??.
 
     :param data: the datetime string to parse
     :param error_subject: Subject string to use in error message
@@ -41,4 +47,9 @@ def parse_datetime(data, error_subject=None, none_safe=False):
     epoch = datetime.strptime('1900-01-01', '%Y-%m-%d')
     if dt < epoch:
         raise ValueError("Dates prior to year 1900 not supported")
+
+    # Correct for python's inappropriate WRAP_YEAR of '69
+    if dt.year > WRAP_YEAR:
+        dt = dt.replace(year=dt.year-100)
+
     return dt

--- a/hydrant/models/patient.py
+++ b/hydrant/models/patient.py
@@ -61,10 +61,12 @@ class Patient(object):
         results = {}
         results['resource'] = self.as_fhir()
         method = 'POST'
+
+        # FHIR spec: 'birthDate'; HAPI search: 'birthdate'
         patient_url = (
             f'Patient?family={self._fields["name"]["family"]}&'
             f'given={self._fields["name"]["given"][0]}&'
-            f'birthdate={self._fields["birthdate"]}')
+            f'birthdate={self._fields["birthDate"]}')
 
         # Round-trip to see if this represents a new or existing Patient
         if target_system:

--- a/hydrant/models/patient.py
+++ b/hydrant/models/patient.py
@@ -11,7 +11,16 @@ class PatientList(object):
     def _parse(self):
         """Use parser and adapter, build up list of available patients"""
         self.items = []
+        keys_seen = set()
         for row in self.parser.rows():
+            # Adapter may define unique_key() - if defined and a previous
+            # entry matches, skip over this "duplicate"
+            if hasattr(self.adapter, 'unique_key'):
+                key = self.adapter(row).unique_key()
+                if key in keys_seen:
+                    continue
+                keys_seen.add(key)
+
             self.items.append(Patient.factory(row, self.adapter))
 
     def patients(self):

--- a/hydrant/models/patient.py
+++ b/hydrant/models/patient.py
@@ -63,14 +63,16 @@ class Patient(object):
         method = 'POST'
 
         # FHIR spec: 'birthDate'; HAPI search: 'birthdate'
-        patient_url = (
-            f'Patient?family={self._fields["name"]["family"]}&'
-            f'given={self._fields["name"]["given"][0]}&'
-            f'birthdate={self._fields["birthDate"]}')
+        patient_url = "Patient"
+        search_params = {
+            "family": self._fields["name"]["family"],
+            "given": self._fields["name"]["given"][0],
+            "birthdate": self._fields["birthDate"],
+        }
 
         # Round-trip to see if this represents a new or existing Patient
         if target_system:
-            response = requests.get('/'.join((target_system, patient_url)))
+            response = requests.get('/'.join((target_system, patient_url)), params=search_params)
             response.raise_for_status()
 
             # extract Patient.id from bundle

--- a/hydrant/models/patient.py
+++ b/hydrant/models/patient.py
@@ -70,7 +70,7 @@ class Patient(object):
 
         # Round-trip to see if this represents a new or existing Patient
         if target_system:
-            response = requests.get(target_system+patient_url)
+            response = requests.get('/'.join((target_system, patient_url)))
             response.raise_for_status()
 
             # extract Patient.id from bundle

--- a/hydrant/views.py
+++ b/hydrant/views.py
@@ -1,5 +1,6 @@
 import click
-from flask import Blueprint, current_app
+from flask import Blueprint, abort, current_app, jsonify
+from flask.json import JSONEncoder
 import requests
 
 from hydrant.models.bundle import Bundle
@@ -11,6 +12,37 @@ base_blueprint = Blueprint('base', __name__, cli_group=None)
 @base_blueprint.route('/')
 def root():
     return {"message": "ok"}
+
+
+@base_blueprint.route('/settings', defaults={'config_key': None})
+@base_blueprint.route('/settings/<string:config_key>')
+def config_settings(config_key):
+    """Non-secret application settings"""
+
+    # workaround no JSON representation for datetime.timedelta
+    class CustomJSONEncoder(JSONEncoder):
+        def default(self, obj):
+            return str(obj)
+    current_app.json_encoder = CustomJSONEncoder
+
+    # return selective keys - not all can be be viewed by users, e.g.secret key
+    blacklist = ('SECRET', 'KEY')
+
+    if config_key:
+        key = config_key.upper()
+        for pattern in blacklist:
+            if pattern in key:
+                abort(status_code=400, messag=f"Configuration key {key} not available")
+        return jsonify({key: current_app.config.get(key)})
+
+    config_settings = {}
+    for key in current_app.config:
+        matches = any(pattern for pattern in blacklist if pattern in key)
+        if matches:
+            continue
+        config_settings[key] = current_app.config.get(key)
+
+    return jsonify(config_settings)
 
 
 @base_blueprint.cli.command("upload")

--- a/hydrant/views.py
+++ b/hydrant/views.py
@@ -48,15 +48,14 @@ def upload_file(filename):
         raise click.BadParameter("no appropriate parsers found; can't continue")
 
     # With parser and adapter at hand, process the data
+    target_system = current_app.config['FHIR_SERVER_URL']
     bundle = Bundle()
     patients = PatientList(parser, adapter)
     for p in patients.patients():
-        bundle.add_entry(p.as_upsert_entry())
+        bundle.add_entry(p.as_upsert_entry(target_system))
 
     fhir_bundle = bundle.as_fhir()
     click.echo(f"  - parsed {fhir_bundle['total']} patients")
-
-    target_system = current_app.config['FHIR_SERVER_URL']
     click.echo(f"  - uploading bundle to {target_system}")
 
     response = requests.post(target_system, json=fhir_bundle)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -19,6 +19,12 @@ def example_csv(datadir):
     return parser
 
 
+@pytest.fixture
+def parser_dups_csv(datadir):
+    parser = CSV_Parser(os.path.join(datadir, 'dups.csv'))
+    return parser
+
+
 def test_csv_headers(parser_skagit1_csv):
     assert parser_skagit1_csv.headers[:2] == ['Pat Last Name', 'Pat First Name']
     assert not set(SkagitAdapter.headers()).difference(set(parser_skagit1_csv.headers))
@@ -39,3 +45,11 @@ def test_example_patients(example_csv):
     for patient in pl.patients():
         fp = patient.as_fhir()
         assert len(fp['identifier']) == 1
+
+
+def test_dups_example(parser_dups_csv):
+    pl = PatientList(parser_dups_csv, SkagitAdapter)
+    assert len(pl.patients()) == 2
+    for patient in pl.patients():
+        fp = patient.as_fhir()
+        assert fp['name']['family'] in ("Potter", "Granger")

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -53,3 +53,4 @@ def test_dups_example(parser_dups_csv):
     for patient in pl.patients():
         fp = patient.as_fhir()
         assert fp['name']['family'] in ("Potter", "Granger")
+        assert fp['birthDate'] in ('1966-01-01', '1972-11-25')

--- a/tests/test_adapters/dups.csv
+++ b/tests/test_adapters/dups.csv
@@ -1,0 +1,5 @@
+Pat Last Name,Pat First Name,Pat DOB,Drug Class Desc,Prescription Name,Written by Prov First Name,Enctr Occur Date
+Potter,Harry,01-01-66,Stimulants - Misc.,"Methylphenidate HCl ER 36 MG OR TB24, 1qd",Dragon,03-22-21
+Potter,Harry,01-01-66,Stimulants - Misc.,"Methylphenidate HCl ER 36 MG OR TB24, 1qd",Dragon,04-21-21
+Potter,Harry,01-01-66,Stimulants - Misc.,"Methylphenidate HCl ER 54 MG OR TB24, 1qd",Dragon,05-09-21
+Granger,Hermione,11-25-72,Stimulants - Misc.,"Methylphenidate HCl 10 MG OR TABS, ud",Dragon,04-25-20

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,20 @@ def test_date_parse():
     assert result.date() == date(year=1950, month=1, day=21)
 
 
+def test_2d_year_wrap():
+    ex = '01-01-66'
+    result = parse_datetime(ex)
+    assert result.year == 1966
+
+    ex2 = '11-28-51'
+    result = parse_datetime(ex2)
+    assert result.year == 1951
+
+    ex3 = '11-25-01'
+    result = parse_datetime(ex3)
+    assert result.year == 2001
+
+
 def test_patient_bundle():
     bundle = Bundle()
     patient = Patient()


### PR DESCRIPTION
Review of upload from Skagit shows lots of duplicate patient rows.  This PR manages by adding a hook in the adapter class, namely if an adapter defines a `unique_key()` method, only the first match is kept.

Enhanced upsert logic to check HAPI store for matching patient; now correctly PUTs with the Patient/id if found vs POST for new, to avoid adding duplicate patients.

Workaround added for 2 digit year - set WRAP_YEAR at 2025 pending feedback in https://www.pivotaltracker.com/story/show/179168443