### PR TITLE
Don't require provider header - not present in all uploads

### DIFF
--- a/hydrant/adapters/sites/skagit.py
+++ b/hydrant/adapters/sites/skagit.py
@@ -13,7 +13,7 @@ class SkagitAdapter(object):
             'Pat Last Name',
             'Pat First Name',
             'Pat DOB',
-            'Written by Prov First Name'
+            #'Written by Prov First Name'
         ]
 
     def __init__(self, parsed_row):


### PR DESCRIPTION
One of Skagit's upload files doesn't include the provider header.  As we're not yet using anyhow, stop requiring. 