### PR TITLE
Include no-cache header when looking for existing patients during import

### DIFF
--- a/hydrant/models/patient.py
+++ b/hydrant/models/patient.py
@@ -72,7 +72,8 @@ class Patient(object):
 
         # Round-trip to see if this represents a new or existing Patient
         if target_system:
-            response = requests.get('/'.join((target_system, patient_url)), params=search_params)
+            headers = {'Cache-Control': 'no-cache'}
+            response = requests.get('/'.join((target_system, patient_url)), params=search_params, headers=headers)
             response.raise_for_status()
 
             # extract Patient.id from bundle


### PR DESCRIPTION
Due to HAPI's default caching queries, patient lookups for recently created patients were inaccurately returning no results.