### PR TITLE
separate event logger

### DIFF
--- a/hydrant/app.py
+++ b/hydrant/app.py
@@ -45,8 +45,8 @@ def configure_logging(app):
     event_logger = logging.getLogger("event_logger")
     event_logger.setLevel(logging.INFO)
     event_logger.addHandler(log_server_handler)
-    app.logger.debug("hydrant <app> logging initialized", extra={'tags': ['testing', 'logging']})
-    event_logger.info("hydrant <event> logging initialized", extra={'tags': ['testing', 'logging']})
+    app.logger.debug("hydrant <app> logging initialized", extra={'tags': ['testing', 'logging', 'app']})
+    event_logger.info("hydrant <event> logging initialized", extra={'tags': ['testing', 'logging', 'events']})
 
 
 def configure_proxy(app):

--- a/hydrant/app.py
+++ b/hydrant/app.py
@@ -42,8 +42,11 @@ def configure_logging(app):
         "%(asctime)s %(name)s %(levelname)s %(message)s")
     log_server_handler.setFormatter(json_formatter)
 
-    app.logger.addHandler(log_server_handler)
-    app.logger.debug("hydrant logging initialized", extra={'tags': ['testing', 'logging']})
+    event_logger = logging.getLogger("event_logger")
+    event_logger.setLevel(logging.INFO)
+    event_logger.addHandler(log_server_handler)
+    app.logger.debug("hydrant <app> logging initialized", extra={'tags': ['testing', 'logging']})
+    event_logger.info("hydrant <event> logging initialized", extra={'tags': ['testing', 'logging']})
 
 
 def configure_proxy(app):

--- a/hydrant/logserverhandler.py
+++ b/hydrant/logserverhandler.py
@@ -1,6 +1,7 @@
 import json
-import logging.handlers
+import logging
 import requests
+from requests.exceptions import RequestException
 
 
 class LogServerHandler(logging.Handler):
@@ -18,4 +19,10 @@ class LogServerHandler(logging.Handler):
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.jwt}"
         }
-        return requests.post(url=self.url, headers=headers, json=log_entry)
+        try:
+            response = requests.post(url=self.url, headers=headers, json=log_entry)
+            response.raise_for_status()
+        except RequestException as ex:
+            # bootstrap problems - attemtp to log to root logger
+            root_logger = logging.getLogger('root')
+            root_logger.exception(ex)

--- a/hydrant/logserverhandler.py
+++ b/hydrant/logserverhandler.py
@@ -23,6 +23,6 @@ class LogServerHandler(logging.Handler):
             response = requests.post(url=self.url, headers=headers, json=log_entry)
             response.raise_for_status()
         except RequestException as ex:
-            # bootstrap problems - attemtp to log to root logger
+            # bootstrap problems - attempt to log to root logger
             root_logger = logging.getLogger('root')
             root_logger.exception(ex)

--- a/hydrant/views.py
+++ b/hydrant/views.py
@@ -1,3 +1,5 @@
+import logging
+
 import click
 from flask import Blueprint, abort, current_app, jsonify
 from flask.json import JSONEncoder
@@ -91,12 +93,13 @@ def upload_file(filename):
     click.echo(f"  - uploading bundle to {target_system}")
     extra = {'tags': ['patient', 'upload'], 'user': 'system'}
     current_app.logger.info(
-        f"attempt to upload {fhir_bundle['total']} patients from {filename}",
+        f"upload {fhir_bundle['total']} patients from {filename}",
         extra=extra)
 
     response = requests.post(target_system, json=fhir_bundle)
     click.echo(f"  - response status {response.status_code}")
-    current_app.logger.info(f"uploaded: {response.json()}", extra=extra)
+    event_logger = logging.getLogger("event_logger")
+    event_logger.info(f"uploaded: {response.json()}", extra=extra)
 
     if response.status_code != 200:
         raise click.BadParameter(response.text)


### PR DESCRIPTION
Isolates event/audit log entries to a separate logger, thus hiding from system logging.
Extended log server handler to report transmission errors (to the log server) on system `root` logger.