### PR TITLE
DocumentReference added for housing `Controlled substance agreement` 

### DIFF
--- a/hydrant/models/document_reference.py
+++ b/hydrant/models/document_reference.py
@@ -1,0 +1,35 @@
+from urllib.parse import urlencode
+
+from hydrant.models.resource import Resource
+
+CONTROLLED_SUBSTANCE_AGREEMENT_CODE = {
+    'system': "https://loinc.org",
+    'code': "94136-9",
+    'display': "Controlled substance agreement"
+}
+
+
+class DocumentReference(Resource):
+    """Minimal FHIR like DocumentReference for parsing / uploading """
+    RESOURCE_TYPE = 'DocumentReference'
+
+    def __init__(self):
+        super().__init__()
+        self._fields['status'] = 'current'
+
+    def search_url(self):
+        """Generate the request path search url for DocumentReference
+
+        NB - this method does NOT invoke a round trip ID lookup.
+        Call self.id() beforehand to force a lookup.
+        """
+        if self._id:
+            return f"{self.RESOURCE_TYPE}/{self._id}"
+
+        first_type = self._fields['type']['coding'][0]
+        search_params = {
+            "subject": self._fields["subject"]["reference"],
+            "type": '|'.join((first_type["system"], first_type["code"])),
+            "date": self._fields["date"],
+        }
+        return f"{self.RESOURCE_TYPE}/?{urlencode(search_params)}"

--- a/hydrant/views.py
+++ b/hydrant/views.py
@@ -144,14 +144,22 @@ def upload_file(filename):
     if filename.endswith('csv'):
         from hydrant.adapters.csv import CSV_Parser
         from hydrant.adapters.sites.kent import KentPatientAdapter
-        from hydrant.adapters.sites.skagit import SkagitPatientAdapter, SkagitServiceRequestAdapter
+        from hydrant.adapters.sites.skagit import (
+            SkagitControlledSubstanceAgreementAdapter,
+            SkagitPatientAdapter,
+            SkagitServiceRequestAdapter,
+        )
         from hydrant.models.resource_list import ResourceList
 
         parser = CSV_Parser(filename)
         headers = set(parser.headers)
 
         # sniff out the site adapter from the header values
-        for site_adapter in (KentPatientAdapter, SkagitPatientAdapter, SkagitServiceRequestAdapter):
+        for site_adapter in (
+                KentPatientAdapter,
+                SkagitPatientAdapter,
+                SkagitControlledSubstanceAgreementAdapter,
+                SkagitServiceRequestAdapter):
             if not set(site_adapter.headers()).difference(headers):
                 if adapter:
                     raise click.BadParameter("column headers match multiple adapters")

--- a/tests/test_adapters/villians_controlled_substance_agreement.csv
+++ b/tests/test_adapters/villians_controlled_substance_agreement.csv
@@ -1,0 +1,35 @@
+Pat Last Name,Pat First Name,Pat DOB,Controlled Substance Agreement Date
+quinn,harley,1993-09-12,2019-10-01
+quinn,harley,1993-09-12,2020-10-01
+osborn,harry,1974-09-01,2021-07-01
+osborn,harry,1974-09-01,2020-12-03
+osborn,harry,1974-09-01,2019-01-02
+luthor,lex,1940-04-23,2020-12-15
+luthor,lex,1940-04-23,2019-12-20
+guerre,martin,1982-06-18,2021-02-13
+guerre,martin,1982-06-18,2020-03-04
+guerre,martin,1982-06-18,2019-01-05
+eisenhardt,max,1963-09-21,2021-08-01
+eisenhardt,max,1963-09-21,2019-12-03
+osborn,norman,1962-07-29,2021-01-03
+osborn,norman,1962-07-29,2019-11-10
+pan,peter,2010-08-06,2020-01-02
+pan,peter,2010-08-06,2019-03-07
+rich,priscilla,1943-10-01,2021-10-01
+rich,priscilla,1943-10-01,2021-06-12
+rich,priscilla,1943-10-01,2021-02-17
+rich,priscilla,1943-10-01,2020-11-09
+rich,priscilla,1943-10-01,2019-12-30
+kingsley,roderick,1983-03-04,2021-02-01
+kingsley,roderick,1983-03-04,2020-05-25
+burns,roy,1985-03-22,2021-03-04
+burns,roy,1985-03-22,2020-03-04
+dickens,charles,1977-01-12,2021-01-31
+dickens,charles,1977-01-12,2019-12-17
+dickens,charles,1977-01-12,2015-12-12
+aurelius,marcus,1975-06-17,2021-10-10
+aurelius,marcus,1975-06-17,2019-01-05
+aurelius,marcus,1975-06-17,2018-09-11
+yung,cheng,1957-08-19, 2020-12-10
+browning,elizabeth,1983-05-03,2020-11-01
+browning,elizabeth,1983-05-03,2020-12-01

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,27 @@
 from datetime import date, datetime
 import json
+import pytest
 from urllib.parse import parse_qs, urlparse
 
 from hydrant.models.bundle import Bundle
 from hydrant.models.datetime import parse_datetime
+from hydrant.models.document_reference import (
+    CONTROLLED_SUBSTANCE_AGREEMENT_CODE,
+    DocumentReference,
+)
 from hydrant.models.patient import Patient
 from hydrant.models.service_request import ServiceRequest
+
+
+@pytest.fixture
+def mock_patient():
+    # Generate a mock patient for tests
+    name = {'family': 'Brown', 'given': ['Charlie']}
+    dob = "1948-05-30"
+
+    patient = Patient(name=name, birthDate=dob)
+    patient._id = '9'
+    return patient
 
 
 def test_date_parse():
@@ -38,20 +54,12 @@ def test_patient_bundle():
     json.dumps(bundle.as_fhir())
 
 
-def test_service_request():
-
-    # Mock patient as subject
-    name = {'family': 'Brown', 'given': ['Charlie']}
-    dob = "1948-05-30"
-    codeable_concept = {"coding": [{'system': 'http://loinc.org', 'code': 'chicken'}]}
-
-    patient = Patient(name=name, birthDate=dob)
-    patient._id = '9'
-
+def test_service_request(mock_patient):
     # Mock ServiceRequest with code
+    codeable_concept = {"coding": [{'system': 'http://loinc.org', 'code': 'chicken'}]}
     svc_req = ServiceRequest()
     svc_req._fields['authoredOn'] = "2021-09-27"
-    svc_req._fields['subject'] = {'reference': patient.search_url()}
+    svc_req._fields['subject'] = {'reference': mock_patient.search_url()}
     svc_req._fields['code'] = codeable_concept
 
     # as FHIR, includes subject reference and codeable concept
@@ -69,3 +77,25 @@ def test_service_request():
     assert(qs['subject'] == ['Patient/9'])
     assert(qs['code'] == ['http://loinc.org|chicken'])
     assert(qs['authored'] == ['2021-09-27'])
+
+
+def test_document_reference(mock_patient):
+    doc_ref = DocumentReference()
+    doc_ref._fields['subject'] = {'reference': mock_patient.search_url()}
+    doc_ref._fields['type'] = {'coding': [CONTROLLED_SUBSTANCE_AGREEMENT_CODE]}
+    doc_ref._fields['date'] = "2020-10-10"
+
+    f = doc_ref.as_fhir()
+    assert(f['subject'] == {'reference': 'Patient/9'})
+    assert(f['type']['coding']) == [CONTROLLED_SUBSTANCE_AGREEMENT_CODE]
+    assert(f['date'] == '2020-10-10')
+
+    # for HAPI search URL - subject points directly to id and code is '|' together
+    s = doc_ref.search_url()
+    parsed = urlparse(s)
+    assert(parsed.path == 'DocumentReference/')
+    assert('Patient' in parsed.query)
+    qs = parse_qs(parsed.query)
+    assert(qs['subject'] == ['Patient/9'])
+    assert(qs['type'] == ['https://loinc.org|94136-9'])
+    assert(qs['date'] == ['2020-10-10'])


### PR DESCRIPTION
Capture controlled substance agreement date(s) in DocumentReference FHIR resources.

Includes adapter to import CSV for Skagit, and test files.  To import example on test system:

`flask upload tests/test_adapters/villians_controlled_substance_agreement.csv`