### PR TITLE
bring in pyscopg and config to connect to KC db

### DIFF
--- a/hydrant/config.py
+++ b/hydrant/config.py
@@ -10,6 +10,14 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 PREFERRED_URL_SCHEME = os.getenv("PREFERRED_URL_SCHEME", 'http')
 FHIR_SERVER_URL = os.getenv('FHIR_SERVER_URL')
 
+# Used to access keycloak db for event log extraction
+DB_VENDOR = os.getenv("DB_VENDOR", "postgres")
+DB_ADDR = os.getenv("DB_ADDR", "db")
+DB_PORT = os.getenv("DB_PORT", "5432")
+DB_DATABASE = os.getenv("DB_DATABASE", "keycloak")
+DB_USER = os.getenv("DB_USER", "postgres")
+DB_PASSWORD = os.getenv("DB_PASSWORD", "postgres")
+
 LOGSERVER_TOKEN = os.getenv('LOGSERVER_TOKEN')
 LOGSERVER_URL = os.getenv('LOGSERVER_URL')
 

--- a/hydrant/models/kc_log_extractor.py
+++ b/hydrant/models/kc_log_extractor.py
@@ -52,7 +52,7 @@ def get_events(db_con):
     with db_con.cursor() as cursor:
         cursor.execute(
             "SELECT user_id, session_id, event_time, type, details_json "
-            " FROM event_entity LIMIT 20")
+            " FROM event_entity")
         for row in cursor:
             yield {
                 "user_id": row[0],

--- a/hydrant/models/kc_log_extractor.py
+++ b/hydrant/models/kc_log_extractor.py
@@ -1,0 +1,73 @@
+"""Module to encapsulate extracting KeyCloak event log data"""
+import datetime
+from flask import current_app
+import json
+import psycopg2
+
+
+def get_con():
+    """Return live DB connection"""
+    return psycopg2.connect(
+        dbname=current_app.config.get("DB_DATABASE"),
+        user=current_app.config.get("DB_USER"),
+        password=current_app.config.get("DB_PASSWORD"),
+        host=current_app.config.get("DB_ADDR"),
+        port=current_app.config.get("DB_PORT")
+    )
+
+
+def get_count(db_con):
+    with db_con.cursor() as cursor:
+        cursor.execute("SELECT count(*) FROM event_entity")
+        row = cursor.fetchone()
+    return row[0]
+
+
+def user_id_name_map(db_con):
+    """Only login events include username - capture mapping"""
+    user_ids = []
+    with db_con.cursor() as cursor:
+        cursor.execute(
+            "SELECT DISTINCT(user_id) FROM event_entity")
+        for row in cursor:
+            if not row[0]:
+                continue
+            user_ids.append(row[0])
+
+    map = {}
+    with db_con.cursor() as cursor:
+        for user_id in user_ids:
+            cursor.execute(
+                "SELECT details_json FROM event_entity "
+                f" WHERE type = 'LOGIN' AND user_id = '{user_id}' LIMIT 1")
+            row = cursor.fetchone()
+            if row:
+                map[user_id] = json.loads(row[0]).get("username", "")
+
+    return map
+
+
+def get_events(db_con):
+    user_name_map = user_id_name_map(db_con)
+    with db_con.cursor() as cursor:
+        cursor.execute(
+            "SELECT user_id, session_id, event_time, type, details_json "
+            " FROM event_entity LIMIT 20")
+        for row in cursor:
+            yield {
+                "user_id": row[0],
+                "user_name": user_name_map.get(row[0], ""),
+                "session_id": row[1],
+                "event_time": datetime.datetime.fromtimestamp(row[2]/1000).isoformat(),
+                "type": row[3],
+                "details": json.loads(row[4]),
+            }
+
+
+def dump_events():
+    con = get_con()
+    results = []
+    for event in get_events(con):
+        results.append(event)
+
+    return results

--- a/hydrant/views.py
+++ b/hydrant/views.py
@@ -193,3 +193,11 @@ def upload_file(filename):
         raise click.BadParameter(response.text)
 
     click.echo("upload complete")
+
+
+
+@base_blueprint.cli.command("kc_logs")
+def kc_logs():
+    import json
+    from hydrant.models.kc_log_extractor import dump_events
+    click.echo(json.dumps(dump_events(), indent=2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
 jmespath==0.10.0          # via hydrant (setup.py)
 markupsafe==1.1.1         # via jinja2
+psycopg2-binary=2.9.3     # via hydrant (setup.py)
 python-dateutil==2.8.0    # via hydrant (setup.py)
 python-json-logger==0.1.11  # via hydrant (setup.py)
 requests==2.24.0          # via hydrant (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
 jmespath==0.10.0          # via hydrant (setup.py)
 markupsafe==1.1.1         # via jinja2
-psycopg2-binary=2.9.3     # via hydrant (setup.py)
+psycopg2-binary==2.9.3     # via hydrant (setup.py)
 python-dateutil==2.8.0    # via hydrant (setup.py)
 python-json-logger==0.1.11  # via hydrant (setup.py)
 requests==2.24.0          # via hydrant (setup.py)


### PR DESCRIPTION
added flask CLI to hydrant to generate a JSON dump of all keycloak events.

example call:
```
cd cosri-environments/dev/freestanding/femr/
dc exec hydrant flask kc_logs
```

generates stdout such as the following:
```
[
  {
    "user_id": "794d2782-e783-4cbb-ae72-b165a4c06e7f",
    "user_name": "test",
    "session_id": "28e84cfc-84ac-4651-b0fb-3ec986703070",
    "event_time": "2021-11-29T20:43:31.164000",
    "type": "LOGIN",
    "details": {
      "auth_method": "openid-connect",
      "auth_type": "code",
      "redirect_uri": "http://dashboard.pb.dev.cosri.cirg.washington.edu/oidc_callback",
      "consent": "no_consent_required",
      "code_id": "28e84cfc-84ac-4651-b0fb-3ec986703070",
      "username": "test"
    }
  },
  [...]
```